### PR TITLE
DeployU connector: nightly one-way ERP→LMS sync (roster, results, attendance)

### DIFF
--- a/srkr_frappe_app_api/deployu_connector/tasks.py
+++ b/srkr_frappe_app_api/deployu_connector/tasks.py
@@ -1,0 +1,286 @@
+"""DeployU Connector — nightly one-way sync: ERP -> DeployU LMS.
+
+Pushes roster (+ promotions), university results and per-course attendance to
+the DeployU ingest APIs. ERP is source of truth; DeployU mirrors, never writes back.
+
+Configuration (site_config.json):
+    "deployu_api_url":       "https://srkr.deployu.ai",
+    "deployu_college_slug":  "srkr",
+    "deployu_erp_api_key":   "<colleges.erp_api_key>",
+    "deployu_sync_enabled":  1,
+    "deployu_sync_dry_run":  0,          # 1 = log payload counts, POST nothing
+    "deployu_sync_programs": []          # optional list of program names to scope
+
+Scheduling (hooks.py):
+    "cron": { "0 3 * * *": ["srkr_frappe_app_api.deployu_connector.tasks.nightly_sync"] }
+    (03:00 IST — after the 02:00 srkr_reports full rebuild, so summaries are fresh.)
+
+Watermarks are stored via frappe defaults (frappe.db get/set_global), so each run
+sends only rows changed since the last successful run. Re-sends are safe — every
+DeployU endpoint is an idempotent upsert.
+"""
+import json
+
+import frappe
+import requests
+
+BATCH = 500
+TIMEOUT = 60
+
+
+# --------------------------------------------------------------------------
+# config / plumbing
+# --------------------------------------------------------------------------
+
+def _cfg():
+    conf = frappe.conf
+    return {
+        "url": (conf.get("deployu_api_url") or "").rstrip("/"),
+        "slug": conf.get("deployu_college_slug"),
+        "key": conf.get("deployu_erp_api_key"),
+        "enabled": bool(conf.get("deployu_sync_enabled")),
+        "dry_run": bool(conf.get("deployu_sync_dry_run")),
+        "programs": conf.get("deployu_sync_programs") or [],
+    }
+
+
+def _post(cfg, path, payload):
+    if cfg["dry_run"]:
+        frappe.logger("deployu").info(f"[DRY RUN] POST {path}: {len(list(payload.values())[1])} rows")
+        return {"dry_run": True}
+    resp = requests.post(
+        f"{cfg['url']}{path}",
+        json=payload,
+        headers={"x-api-key": cfg["key"], "Content-Type": "application/json"},
+        timeout=TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _chunks(rows):
+    for i in range(0, len(rows), BATCH):
+        yield rows[i : i + BATCH]
+
+
+def _get_watermark(name):
+    return frappe.db.get_global(f"deployu_wm_{name}") or "2000-01-01 00:00:00"
+
+
+def _set_watermark(name, value):
+    frappe.db.set_global(f"deployu_wm_{name}", value)
+    frappe.db.commit()
+
+
+def _program_filter(cfg, column):
+    if not cfg["programs"]:
+        return "", []
+    ph = ", ".join(["%s"] * len(cfg["programs"]))
+    return f" AND {column} IN ({ph})", list(cfg["programs"])
+
+
+def _log_run(kind, sent, response, errors):
+    frappe.logger("deployu").info(
+        json.dumps({"job": kind, "sent": sent, "response": response, "errors": errors[:10]})
+    )
+
+
+# --------------------------------------------------------------------------
+# 1. roster (students + section + current semester -> drives promotion/gating)
+# --------------------------------------------------------------------------
+
+def sync_students(cfg=None):
+    cfg = cfg or _cfg()
+    pf, pv = _program_filter(cfg, "pe.program")
+    rows = frappe.db.sql(
+        f"""
+        SELECT s.name AS erp_id, s.student_name, s.custom_student_id AS roll_number,
+               LOWER(TRIM(s.student_email_id)) AS email,
+               pe.program, pe.current_semester,
+               sg.batch AS erp_batch_name, sg.name AS erp_group_name
+        FROM `tabStudent` s
+        JOIN `tabProgram Enrollment` pe ON pe.student = s.name AND pe.docstatus < 2
+        LEFT JOIN (
+            SELECT sgs.student, sg2.batch, sg2.name,
+                   ROW_NUMBER() OVER (PARTITION BY sgs.student ORDER BY sg2.academic_year DESC) rn
+            FROM `tabStudent Group` sg2
+            JOIN `tabStudent Group Student` sgs ON sgs.parent = sg2.name
+            WHERE sg2.group_based_on = 'Batch'
+        ) sg ON sg.student = s.name AND sg.rn = 1
+        WHERE s.enabled = 1 AND s.custom_student_id IS NOT NULL
+          AND pe.current_semester LIKE 'SEM-%'{pf}
+        """,
+        pv,
+        as_dict=True,
+    )
+
+    # ERP batch name -> LMS batch id is resolved on the DeployU side via
+    # erp_batch_mappings; we send names. Section letter parsed from group name.
+    students = []
+    for r in rows:
+        if not r.email or not r.roll_number:
+            continue
+        sem = int(r.current_semester.split("-")[1])
+        section = None
+        if r.erp_group_name and "-SEM-" in r.erp_group_name:
+            tail = r.erp_group_name.rsplit("-", 1)[-1]
+            section = tail if len(tail) == 1 and tail.isalpha() else None
+        students.append({
+            "email": r.email,
+            "full_name": r.student_name,
+            "roll_number": r.roll_number,
+            "erp_batch_name": r.erp_batch_name,
+            "current_year": (sem + 1) // 2,
+            "current_sem_number": sem,
+            "section": section,
+        })
+
+    errors, resp = [], {}
+    for chunk in _chunks(students):
+        resp = _post(cfg, "/api/admin/college/sync-students",
+                     {"college_slug": cfg["slug"], "students": chunk})
+        errors += resp.get("errors", []) if isinstance(resp, dict) else []
+    _log_run("students", len(students), resp, errors)
+    return {"sent": len(students), "errors": len(errors)}
+
+
+# --------------------------------------------------------------------------
+# 2. results (semester rollup + subject detail)
+# --------------------------------------------------------------------------
+
+def sync_results(cfg=None):
+    cfg = cfg or _cfg()
+    wm = _get_watermark("results")
+    parents = frappe.db.sql(
+        """
+        SELECT esr.name, esr.student, esr.semester_number, esr.sgpa, esr.exam_status,
+               esr.modified, s.custom_student_id AS roll_number
+        FROM `tabExam Semester Result` esr
+        JOIN `tabStudent` s ON s.name = esr.student
+        WHERE esr.modified > %s AND s.custom_student_id IS NOT NULL
+        ORDER BY esr.modified
+        """,
+        (wm,),
+        as_dict=True,
+    )
+    if not parents:
+        _log_run("results", 0, {"note": "no changes since watermark"}, [])
+        return {"sent": 0}
+
+    names = [p.name for p in parents]
+    ph = ", ".join(["%s"] * len(names))
+    subj = frappe.db.sql(
+        f"""SELECT parent, subject_code, subject_name, credits, grade, result, exammy
+            FROM `tabExam Subject Result` WHERE parent IN ({ph})""",
+        names,
+        as_dict=True,
+    )
+    by_parent = {}
+    for srow in subj:
+        by_parent.setdefault(srow.parent, []).append({
+            "code": srow.subject_code, "name": srow.subject_name,
+            "credits": float(srow.credits or 0), "grade": srow.grade,
+            "result": srow.result, "exam_month_year": srow.exammy,
+        })
+
+    results = [{
+        "roll_number": p.roll_number,
+        "semester_number": int(p.semester_number),
+        "sgpa": float(p.sgpa) if p.sgpa is not None else None,
+        "exam_status": p.exam_status,
+        "subjects": by_parent.get(p.name, []),
+    } for p in parents]
+
+    errors, resp = [], {}
+    for chunk in _chunks(results):
+        resp = _post(cfg, "/api/admin/college/sync-results",
+                     {"college_slug": cfg["slug"], "results": chunk})
+        errors += resp.get("errors", []) if isinstance(resp, dict) else []
+    if not cfg["dry_run"]:
+        _set_watermark("results", str(parents[-1].modified))
+    _log_run("results", len(results), resp, errors)
+    return {"sent": len(results), "errors": len(errors)}
+
+
+# --------------------------------------------------------------------------
+# 3. attendance (straight copy of rpt_student_course_term rows)
+# --------------------------------------------------------------------------
+
+def sync_attendance(cfg=None):
+    cfg = cfg or _cfg()
+    wm = _get_watermark("attendance")
+    pf, pv = _program_filter(cfg, "r.program")
+    rows = frappe.db.sql(
+        f"""
+        SELECT r.custom_student_id AS roll_number, r.academic_year, r.academic_term,
+               r.program_semester, r.course, r.course_name,
+               r.present_count, r.absent_count, r.classes_held, r.attendance_pct,
+               r.last_refreshed
+        FROM srkr_reports.rpt_student_course_term r
+        WHERE r.last_refreshed > %s AND r.custom_student_id IS NOT NULL{pf}
+        ORDER BY r.last_refreshed
+        """,
+        [wm] + pv,
+        as_dict=True,
+    )
+    if not rows:
+        _log_run("attendance", 0, {"note": "no changes since watermark"}, [])
+        return {"sent": 0}
+
+    attendance = []
+    for r in rows:
+        code = None
+        if r.course and r.course.rstrip().endswith(")") and "(" in r.course:
+            code = r.course.rstrip()[:-1].rsplit("(", 1)[-1].strip() or None
+        sem = None
+        if r.program_semester and r.program_semester.startswith("SEM-"):
+            sem = int(r.program_semester.split("-")[1])
+        attendance.append({
+            "roll_number": r.roll_number,
+            "academic_year": r.academic_year,
+            "academic_term": r.academic_term,
+            "semester_number": sem,
+            "course_code": code,
+            "course_name": (r.course_name or r.course or "?")[:200],
+            "present": int(r.present_count or 0),
+            "absent": int(r.absent_count or 0),
+            "held": int(r.classes_held or 0),
+            "pct": float(r.attendance_pct) if r.attendance_pct is not None else None,
+            "last_refreshed": str(r.last_refreshed) if r.last_refreshed else None,
+        })
+
+    errors, resp = [], {}
+    for chunk in _chunks(attendance):
+        resp = _post(cfg, "/api/admin/college/sync-attendance",
+                     {"college_slug": cfg["slug"], "attendance": chunk})
+        errors += resp.get("errors", []) if isinstance(resp, dict) else []
+    if not cfg["dry_run"]:
+        _set_watermark("attendance", str(rows[-1].last_refreshed))
+    _log_run("attendance", len(attendance), resp, errors)
+    return {"sent": len(attendance), "errors": len(errors)}
+
+
+# --------------------------------------------------------------------------
+# entry point
+# --------------------------------------------------------------------------
+
+def nightly_sync():
+    """Cron entry point — roster first (identity), then marks, then attendance."""
+    cfg = _cfg()
+    if not cfg["enabled"]:
+        frappe.logger("deployu").info("deployu sync disabled (deployu_sync_enabled=0)")
+        return
+    if not (cfg["url"] and cfg["slug"] and cfg["key"]):
+        frappe.logger("deployu").error("deployu sync misconfigured — missing url/slug/key")
+        return
+    summary = {}
+    for name, fn in (("students", sync_students),
+                     ("results", sync_results),
+                     ("attendance", sync_attendance)):
+        try:
+            summary[name] = fn(cfg)
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), f"DeployU sync failed: {name}")
+            summary[name] = {"error": True}
+    frappe.logger("deployu").info(json.dumps({"nightly_sync": summary}))
+    return summary

--- a/srkr_frappe_app_api/hooks.py
+++ b/srkr_frappe_app_api/hooks.py
@@ -166,6 +166,13 @@ scheduler_events = {
 		"srkr_frappe_app_api.examination.tasks.sync_all_active_students"
 	],
     "cron": {
+        # DeployU connector — nightly one-way sync (roster, results, attendance)
+        # at 03:00, after the 02:00 srkr_reports full rebuild so summaries are
+        # fresh. Config: deployu_* keys in site_config.json; no-op unless
+        # deployu_sync_enabled=1.
+        "0 3 * * *": [
+            "srkr_frappe_app_api.deployu_connector.tasks.nightly_sync"
+        ],
         # This is your existing job that runs at 6:00 PM
         "0 18 * * *": [
             "srkr_frappe_app_api.instructor.api.send_daily_attendance_summary"


### PR DESCRIPTION
## What this is

The sender side of the ERP↔DeployU integration: a nightly job that pushes roster (with promotions/sections), university results, and per-course attendance to the DeployU LMS ingest APIs. One-way by design — **ERP remains source of truth; the connector never writes to ERP doctypes** (only two watermark globals via `frappe.db.set_global`).

Receiver side (already on the LMS: `sync-students`, `sync-results`, `sync-attendance` — x-api-key auth, idempotent upserts) shipped in deployu-lms-app PR #643.

## Design

- **Attendance is a straight copy of `srkr_reports.rpt_student_course_term`** — the same Dean-approved, parity-tested summary grain the academics portal reads. The connector copies rows; it computes nothing.
- **Watermarked incrementals**: results by `Exam Semester Result.modified`, attendance by `rpt.last_refreshed` — a failed night simply re-runs; every LMS endpoint upserts.
- **Cron 03:00**, one hour after the 02:00 srkr_reports full rebuild, so summaries are always fresh.
- **Per-job failure isolation**: roster failing doesn't block results/attendance; each job logs a summary line + `frappe.log_error` on exceptions.

## Safety

**Merging this is a no-op.** The job exits immediately unless `site_config.json` sets `deployu_sync_enabled: 1`. Full config:

```json
"deployu_api_url": "https://srkr.deployu.ai",
"deployu_college_slug": "srkr",
"deployu_erp_api_key": "<colleges.erp_api_key>",
"deployu_sync_enabled": 1,
"deployu_sync_dry_run": 1,
"deployu_sync_programs": []
```

Recommended first run: `deployu_sync_dry_run: 1` (logs payload counts, POSTs nothing), validated against the srkr1 dev tenant before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)